### PR TITLE
아이디,비번 찾기 페이지 + authHeader

### DIFF
--- a/frontend/eco-insight/src/App.jsx
+++ b/frontend/eco-insight/src/App.jsx
@@ -29,6 +29,11 @@ import Notice from "./components/Board/Notice/Notice.jsx";
 import Login from "./components/Auth/Login.jsx";
 import FrequencyAskPage from "./components/Ask/FrequencyAskPage.jsx";
 import PrivateAskPage from "./components/Ask/PrivateAskPage.jsx";
+import FindId from "./components/Auth/FindId.jsx";
+import IdResult from "./components/Auth/IdResult.jsx";
+import FindPasswordPage from "./components/Auth/FindPassword.jsx";
+import ResetPassword from "./components/Auth/ResetPassword.jsx";
+
 
 function App() {
   return (
@@ -52,8 +57,13 @@ function App() {
           <Route path="/notice" element={<Notice />} />
           <Route path="/frequencyAskPage" element={<FrequencyAskPage />} />
           <Route path="/privateAskPage" element={<PrivateAskPage />} />
+          <Route path="/find-id/idresult" element={<IdResult />} />
+          <Route path="/findPassword/resetpassword" element={<ResetPassword />} />
+          
         </Route>
         <Route path="/login" element={<Login />}/>
+        <Route path="/findid" element={<FindId />}/>
+        <Route path="/findpassword" element={<FindPasswordPage />} />
         {/* 관리자 전용 */}
         <Route path="/admin" element={<Navigate to="/admin/login" replace />} />
         <Route path="/admin/login" element={<AdminLogin />} />

--- a/frontend/eco-insight/src/components/Auth/FindId.jsx
+++ b/frontend/eco-insight/src/components/Auth/FindId.jsx
@@ -1,0 +1,124 @@
+// src/pages/FindIdPage/FindIdPage.jsx
+import React, { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import AuthHeader from "../Common/AuthHeader/AuthHeader"
+
+const FindIdPage = () => {
+  const navigate = useNavigate();
+
+  const [name, setName] = useState('');
+  const [email, setEmail] = useState('');
+  const [code, setCode] = useState('');
+  const [isCodeSent, setIsCodeSent] = useState(false);
+  const [isCodeVerified, setIsCodeVerified] = useState(false);
+
+  const handleSendCode = () => {
+    // TODO: 이메일로 인증번호 요청 API 호출
+    setIsCodeSent(true);
+    alert('인증번호가 발송되었습니다.');
+  };
+
+  const handleVerifyCode = () => {
+    // TODO: 인증번호 확인 API 호출
+    setIsCodeVerified(true);
+    alert('인증이 완료되었습니다.');
+  };
+
+  const handleNext = () => {
+    if (!isCodeVerified) {
+      alert('먼저 인증을 완료해주세요.');
+      return;
+    }
+    // 아이디 조회 결과 페이지로 이동
+    navigate('/find-id/idresult');
+  };
+
+  return (
+    <div className="flex flex-col min-h-screen bg-gray-50">
+      {/* 공통 헤더 */}
+      <AuthHeader />
+
+      <main className="flex-grow container mx-auto px-4 py-12">
+        <h2 className="text-xl font-semibold mb-8">아이디 찾기</h2>
+
+        <div className="flex flex-col md:flex-row bg-white p-8 rounded-2xl shadow-md">
+          {/* 왼쪽 폼 */}
+          <div className="flex-1">
+            <div className="space-y-6">
+              {/* 이름 */}
+              <div>
+                <label className="block mb-1 text-gray-700">이름</label>
+                <input
+                  type="text"
+                  value={name}
+                  onChange={e => setName(e.target.value)}
+                  placeholder="이름 입력하세요"
+                  className="w-full h-12 px-4 border border-gray-300 rounded-lg focus:outline-none"
+                />
+              </div>
+
+              {/* 이메일 */}
+              <div className="flex items-center space-x-4">
+                <div className="flex-1">
+                  <label className="block mb-1 text-gray-700">이메일 주소</label>
+                  <input
+                    type="email"
+                    value={email}
+                    onChange={e => setEmail(e.target.value)}
+                    placeholder="이메일 입력하세요"
+                    className="w-full h-12 px-4 border border-gray-300 rounded-lg focus:outline-none"
+                  />
+                </div>
+                <button
+                  type="button"
+                  onClick={handleSendCode}
+                  className={`h-12 px-4 rounded-lg text-white ${
+                    isCodeSent ? 'bg-gray-400' : 'bg-green-400 hover:bg-green-500'
+                  }`}
+                >
+                  {isCodeSent ? '다시받기' : '인증번호 받기'}
+                </button>
+              </div>
+
+              {/* 인증번호 */}
+              <div className="flex items-center space-x-4">
+                <div className="flex-1">
+                  <label className="block mb-1 text-gray-700">인증번호 입력</label>
+                  <input
+                    type="text"
+                    value={code}
+                    onChange={e => setCode(e.target.value)}
+                    placeholder="인증번호 6자리 숫자 입력"
+                    className="w-full h-12 px-4 border border-gray-300 rounded-lg focus:outline-none"
+                  />
+                </div>
+                <button
+                  type="button"
+                  onClick={handleVerifyCode}
+                  className={`h-12 px-4 rounded-lg text-white ${
+                    isCodeVerified ? 'bg-gray-400' : 'bg-green-400 hover:bg-green-500'
+                  }`}
+                >
+                  인증번호 확인
+                </button>
+              </div>
+
+              {/* 다음 버튼 */}
+              <div className="text-center">
+                <button
+                  type="button"
+                  onClick={handleNext}
+                  className="mt-4 w-32 h-12 bg-green-400 hover:bg-green-500 text-white rounded-lg"
+                >
+                  다음
+                </button>
+              </div>
+            </div>
+          </div>
+        </div>
+      </main>
+    </div>
+  );
+};
+
+export default FindIdPage;

--- a/frontend/eco-insight/src/components/Auth/FindPassword.jsx
+++ b/frontend/eco-insight/src/components/Auth/FindPassword.jsx
@@ -1,0 +1,122 @@
+// src/pages/FindPasswordPage/FindPasswordPage.jsx
+import React, { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import AuthHeader from '../../components/Common/AuthHeader/AuthHeader';
+
+const FindPasswordPage = () => {
+  const navigate = useNavigate();
+
+  const [memberId, setMemberId] = useState('');
+  const [email, setEmail] = useState('');
+  const [code, setCode] = useState('');
+  const [isCodeSent, setIsCodeSent] = useState(false);
+  const [isCodeVerified, setIsCodeVerified] = useState(false);
+
+  const handleSendCode = () => {
+    // TODO: 이메일로 인증번호 요청 API 호출
+    setIsCodeSent(true);
+    alert('인증번호가 발송되었습니다.');
+  };
+
+  const handleVerifyCode = () => {
+    // TODO: 인증번호 확인 API 호출
+    setIsCodeVerified(true);
+    alert('인증이 완료되었습니다.');
+  };
+
+  const handleNext = () => {
+    if (!isCodeVerified) {
+      alert('먼저 인증을 완료해주세요.');
+      return;
+    }
+    // 비밀번호 재설정 페이지로 이동
+    navigate('/findpassword/resetpassword');
+  };
+
+  return (
+    <div className="flex flex-col min-h-screen bg-gray-50">
+      {/* 공통 헤더 */}
+      <AuthHeader />
+
+      <main className="flex-grow container mx-auto px-4 py-12">
+        <h2 className="text-xl font-semibold mb-8">비밀번호 찾기</h2>
+
+        <div className="flex flex-col md:flex-row bg-white p-8 rounded-2xl shadow-md">
+          {/* 폼 영역 */}
+          <div className="flex-1 space-y-6">
+            {/* 아이디 입력 */}
+            <div>
+              <label className="block mb-1 text-gray-700">아이디</label>
+              <input
+                type="text"
+                value={memberId}
+                onChange={e => setMemberId(e.target.value)}
+                placeholder="아이디를 입력하세요"
+                className="w-full h-12 px-4 border border-gray-300 rounded-lg focus:outline-none"
+              />
+            </div>
+
+            {/* 이메일 + 인증번호 받기 */}
+            <div className="flex items-center space-x-4">
+              <div className="flex-1">
+                <label className="block mb-1 text-gray-700">이메일</label>
+                <input
+                  type="email"
+                  value={email}
+                  onChange={e => setEmail(e.target.value)}
+                  placeholder="이메일을 입력하세요"
+                  className="w-full h-12 px-4 border border-gray-300 rounded-lg focus:outline-none"
+                />
+              </div>
+              <button
+                type="button"
+                onClick={handleSendCode}
+                className={`h-12 px-4 rounded-lg text-white ${
+                  isCodeSent ? 'bg-gray-400' : 'bg-green-400 hover:bg-green-500'
+                }`}
+              >
+                {isCodeSent ? '다시받기' : '인증번호 받기'}
+              </button>
+            </div>
+
+            {/* 인증번호 입력 + 확인 */}
+            <div className="flex items-center space-x-4">
+              <div className="flex-1">
+                <label className="block mb-1 text-gray-700">인증번호 입력</label>
+                <input
+                  type="text"
+                  value={code}
+                  onChange={e => setCode(e.target.value)}
+                  placeholder="인증번호 6자리 숫자 입력"
+                  className="w-full h-12 px-4 border border-gray-300 rounded-lg focus:outline-none"
+                />
+              </div>
+              <button
+                type="button"
+                onClick={handleVerifyCode}
+                className={`h-12 px-4 rounded-lg text-white ${
+                  isCodeVerified ? 'bg-gray-400' : 'bg-green-400 hover:bg-green-500'
+                }`}
+              >
+                인증번호 확인
+              </button>
+            </div>
+
+            {/* 다음 버튼 */}
+            <div className="text-center">
+              <button
+                type="button"
+                onClick={handleNext}
+                className="mt-4 w-32 h-12 bg-green-400 hover:bg-green-500 text-white rounded-lg transition"
+              >
+                다음
+              </button>
+            </div>
+          </div>
+        </div>
+      </main>
+    </div>
+  );
+};
+
+export default FindPasswordPage;

--- a/frontend/eco-insight/src/components/Auth/IdResult.jsx
+++ b/frontend/eco-insight/src/components/Auth/IdResult.jsx
@@ -1,0 +1,62 @@
+// src/pages/FindIdResultPage/FindIdResultPage.jsx
+import React from 'react';
+import { useNavigate, useLocation } from 'react-router-dom';
+
+
+{/* 예: FindIdPage.jsx 의 handleNext 함수
+navigate('/find-id/idresult', {
+  state: {
+    foundId: '사용자123',      // 실제 API 결과로 대체
+    joinDate: '2023.05.17',    // YYYY.MM.DD 형식
+  }
+});
+
+이거는 state 넘길때 사용하세요
+ */}
+
+
+
+const FindIdResultPage = () => {
+  const navigate = useNavigate();
+  const { state } = useLocation();
+  const { foundId = '-', joinDate = '-' } = state || {};
+
+  return (
+    <div className="flex flex-col min-h-screen bg-gray-50">
+    
+
+      <main className="flex-grow container mx-auto px-4 py-12">
+        <h2 className="text-xl font-semibold mb-4">아이디 찾기 결과</h2>
+        <p className="text-sm text-gray-600 mb-6">
+          고객님의 정보와 일치하는 아이디 목록입니다.
+        </p>
+
+        <div className="bg-white rounded-2xl p-8 shadow-md mb-8">
+          <div className="flex flex-col md:flex-row items-center justify-between">
+            <span className="text-lg font-medium">아이디아이디</span>
+            <span className="text-sm text-gray-500">2025-04-17</span>
+          </div>
+        </div>
+
+        <div className="flex flex-col sm:flex-row items-center justify-center space-y-4 sm:space-y-0 sm:space-x-4">
+          <button
+            onClick={() => navigate('/login')}
+            className="w-full sm:w-auto px-6 py-2 bg-green-400 text-white rounded hover:bg-green-500 transition"
+          >
+            로그인하기
+          </button>
+          <button
+            onClick={() => navigate('/findPassword')}
+            className="w-full sm:w-auto px-6 py-2 bg-gray-200 text-gray-700 rounded hover:bg-gray-300 transition"
+          >
+            비밀번호 찾기
+          </button>
+        </div>
+      </main>
+
+     
+    </div>
+  );
+};
+
+export default FindIdResultPage;

--- a/frontend/eco-insight/src/components/Auth/ResetPassword.jsx
+++ b/frontend/eco-insight/src/components/Auth/ResetPassword.jsx
@@ -1,0 +1,34 @@
+// src/pages/FindPasswordPage/ResetPassword.jsx
+import React from 'react';
+import { useNavigate } from 'react-router-dom';
+
+const ResetPassword = () => {
+  const navigate = useNavigate();
+
+  const handleReset = () => {
+    navigate('/changepassword'); // ChangePassword.jsx가 매핑된 경로로 변경하세요
+  };
+
+  return (
+    <div className="flex flex-col min-h-screen bg-gray-50">
+
+      <main className="flex-grow flex items-center justify-center px-4 py-12">
+        <div className="bg-white w-full max-w-md p-8 rounded-2xl shadow-md">
+          <p className="text-center text-gray-700 mb-6">
+            로그인을 위하여 비밀번호 재설정이 필요합니다.
+          </p>
+          <div className="flex justify-center">
+            <button
+              onClick={handleReset}
+              className="px-6 py-2 bg-green-400 hover:bg-green-500 text-white rounded-lg transition"
+            >
+              비밀번호 재설정하기
+            </button>
+          </div>
+        </div>
+      </main>
+    </div>
+  );
+};
+
+export default ResetPassword;

--- a/frontend/eco-insight/src/components/Common/AuthHeader/AuthHeader.jsx
+++ b/frontend/eco-insight/src/components/Common/AuthHeader/AuthHeader.jsx
@@ -1,0 +1,62 @@
+
+import React from 'react';
+import { useNavigate, useLocation } from 'react-router-dom';
+import logo from '../../../assets/EcoInsigthLogo2.png';
+
+const AuthHeader = () => {
+  const navigate = useNavigate();
+  const { pathname } = useLocation();
+
+  const isFindId       = pathname === '/findId';
+  const isFindPassword = pathname === '/findPassword';
+
+  return (
+    <header className="flex items-center justify-between bg-white px-6 py-4 shadow">
+      {/* 로고 */}
+      <div className="flex items-center">
+        <img
+          src={logo}
+          alt="EcoInsight Logo"
+          className="h-14 w-auto"
+        />
+      </div>
+
+      {/* 뒤로가기 + 탭 버튼들 */}
+      <div className="flex items-center space-x-4">
+        {/* 뒤로가기 */}
+        <button
+          onClick={() => navigate(-1)}
+          className="px-4 py-1 bg-lime-400 rounded text-white font-bold hover:bg-lime-500 transition"
+        >
+          뒤로가기
+        </button>
+
+        {/* 아이디 찾기 */}
+        <button
+          onClick={() => navigate('/findId')}
+          className={`px-4 py-1 rounded transition ${
+            isFindId
+              ? 'bg-lime-400 text-white'
+              : 'text-gray-600 hover:bg-gray-100'
+          }`}
+        >
+          아이디 찾기
+        </button>
+
+        {/* 비밀번호 찾기 */}
+        <button
+          onClick={() => navigate('/findPassword')}
+          className={`px-4 py-1 rounded transition ${
+            isFindPassword
+              ? 'bg-lime-400 text-white'
+              : 'text-gray-600 hover:bg-gray-100'
+          }`}
+        >
+          비밀번호 찾기
+        </button>
+      </div>
+    </header>
+  );
+};
+
+export default AuthHeader;


### PR DESCRIPTION
[2025/04/17 12:29] 김태윤

회원 아이디찾기, 비밀번호 찾기 페이지를 만들었습니다.
아이디찾기, 비밀번호 찾기는 authheader를 따로 만들어서 적용했습니다.
authheader에서는 사용자가 버튼활성화를 통해 어떤 페이지에 있는지 알 수 있습니다. 
결과페이지에서 사용자의 아이디와 비밀번호를 보여줍니다.
비밀번호결과 페이지는 비밀번호 수정페이지로 이동하는 버튼을 만들어 로그인 후 바로 비밀번호를 수정하도록 할 예정입니다.