### PR TITLE
이메일 인증 앞단 생성 및 이메일 인증 코드 전송 기능 구현, 이메일 코드 인증 미구현

### DIFF
--- a/EcoInsight/src/main/java/com/semi/ecoinsight/auth/controller/AuthController.java
+++ b/EcoInsight/src/main/java/com/semi/ecoinsight/auth/controller/AuthController.java
@@ -2,6 +2,7 @@ package com.semi.ecoinsight.auth.controller;
 
 import java.util.Map;
 
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -26,8 +27,20 @@ public class AuthController {
     private final TokenService tokenService;
 
     @PostMapping("/login")
-    public ResponseEntity<?> login(@Valid @RequestBody MemberDTO member){
+    public ResponseEntity<Map<String, Object>> login(@Valid @RequestBody MemberDTO member){
         Map<String, Object> loginResponse = authService.login(member);
         return ResponseEntity.ok(loginResponse);
+    }
+
+    @PostMapping("/send-code")
+    public ResponseEntity<Map<String, String>> sendCodeEmail(@RequestBody String email){
+        Map<String, String> verifyCodeResult = authService.sendCodeEmail(email);
+        return ResponseEntity.status(HttpStatus.CREATED).body(verifyCodeResult);
+    }
+
+    @PostMapping("/verify-code")
+    public ResponseEntity<String> verifyCodeEmail(@RequestBody Map<String, String> verifyInfo){
+        String successMsg = authService.verifyCodeEmail(verifyInfo);
+        return ResponseEntity.ok(successMsg);
     }
 }

--- a/EcoInsight/src/main/java/com/semi/ecoinsight/auth/model/dao/AuthMapper.java
+++ b/EcoInsight/src/main/java/com/semi/ecoinsight/auth/model/dao/AuthMapper.java
@@ -1,0 +1,12 @@
+package com.semi.ecoinsight.auth.model.dao;
+
+import java.util.Map;
+
+import org.apache.ibatis.annotations.Mapper;
+
+@Mapper
+public interface AuthMapper {
+
+    void sendCodeEmail(Map<String, String> result);
+    
+}

--- a/EcoInsight/src/main/java/com/semi/ecoinsight/auth/model/service/AuthService.java
+++ b/EcoInsight/src/main/java/com/semi/ecoinsight/auth/model/service/AuthService.java
@@ -6,4 +6,6 @@ import com.semi.ecoinsight.member.model.dto.MemberDTO;
 
 public interface AuthService {
     Map<String, Object> login(MemberDTO member);
+    Map<String, String> sendCodeEmail(String email);
+    String verifyCodeEmail(Map<String, String> verifyInfo);
 }

--- a/EcoInsight/src/main/java/com/semi/ecoinsight/auth/model/service/AuthServiceImpl.java
+++ b/EcoInsight/src/main/java/com/semi/ecoinsight/auth/model/service/AuthServiceImpl.java
@@ -3,7 +3,8 @@ package com.semi.ecoinsight.auth.model.service;
 import java.util.HashMap;
 import java.util.Map;
 
-
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.mail.javamail.MimeMessageHelper;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
@@ -16,6 +17,8 @@ import com.semi.ecoinsight.exception.util.CustomAuthenticationException;
 import com.semi.ecoinsight.member.model.dto.MemberDTO;
 import com.semi.ecoinsight.token.model.service.TokenService;
 
+import jakarta.mail.MessagingException;
+import jakarta.mail.internet.MimeMessage;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
@@ -26,6 +29,7 @@ public class AuthServiceImpl implements AuthService{
 
     private final AuthenticationManager authenticationManager;
     private final TokenService tokenService;
+    private final JavaMailSender sender;
     @Override
     public Map<String, Object> login(MemberDTO member) {
         Authentication authentication = null;
@@ -54,6 +58,56 @@ public class AuthServiceImpl implements AuthService{
         loginResponse.put("loginInfo",loginInfo);
         log.info("loginResponse = {}", loginResponse);
         return loginResponse;
+    }
+    @Override
+    public Map<String, String> sendCodeEmail(String email) {
+        int verifyCode = verifyCodeCreate();
+        MimeMessage message = sender.createMimeMessage();
+        try{
+            MimeMessageHelper helper = new MimeMessageHelper(message,false, "UTF-8");
+            helper.setTo(email);
+            helper.setSubject("Eco-Insight 이메일 인증 번호입니다.");
+            helper.setText(
+                """
+            <div style="width:100%; background:#f4f4f4; padding:20px; font-family:Arial,sans-serif;">
+              <div style="max-width:600px; margin:0 auto; background:#fff; border-radius:8px; overflow:hidden;">
+                <div style="background:#4CAF50; color:#fff; padding:20px; text-align:center;">
+                  <h1>Eco-Insight 이메일 인증</h1>
+                </div>
+                <div style="padding:20px; color:#333;">
+                  <p>안녕하세요,</p>
+                  <p>아래 인증 코드를 입력하여 이메일 인증을 완료해주세요.</p>
+                  <div style="text-align:center; margin:20px 0;">
+                    <span style="display:inline-block; font-size:24px; font-weight:bold; color:#4CAF50;
+                                 padding:10px 20px; border:2px dashed #4CAF50; border-radius:4px;">
+                      """ + verifyCode + """
+                    </span>
+                  </div>
+                  <p>인증 코드는 <strong>3분</strong> 동안 유효합니다.</p>
+                  <p>감사합니다.</p>
+                </div>
+              </div>
+            </div>
+                """,true);
+
+        } catch(MessagingException e){
+            e.printStackTrace();
+        }
+        Map<String, String> result = new HashMap<>();
+        result.put("email",email);
+        result.put("verifyCode", String.valueOf(verifyCode));
+
+        return result;
+    }
+
+    private int verifyCodeCreate(){
+        int verifyCode = (int)(Math.random() * (90000))+ 100000;
+        return verifyCode;
+    }
+    @Override
+    public String verifyCodeEmail(Map<String, String> verifyInfo) {
+        // TODO Auto-generated method stub
+        throw new UnsupportedOperationException("Unimplemented method 'verifyCodeEmail'");
     }
 
 }

--- a/EcoInsight/src/main/resources/mapper/auth-mapper.xml
+++ b/EcoInsight/src/main/resources/mapper/auth-mapper.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" "https://mybatis.org/dtd/mybatis-3-mapper.dtd">
+<mapper namespace="com.semi.ecoinsight.auth.model.AuthMapper">
+    <insert id="sendCodeEmail">
+        INSERT INTO 
+            TB_EMAIL_VERIFY_CODE(
+                EMAIL, VERIFY_CODE
+            ) VALUES(
+                #{email}, #{verifyCode}
+            )
+    </insert>
+</mapper>

--- a/frontend/eco-insight/src/components/Auth/Regex.jsx
+++ b/frontend/eco-insight/src/components/Auth/Regex.jsx
@@ -1,7 +1,7 @@
 // src/components/Member/SignUp/Regex.js
 export const idRegex     = /^[a-zA-Z0-9]{4,12}$/;
-export const pwRegex     = /^(?=.*[A-Za-z])(?=.*\\d)[A-Za-z\\d]{6,20}$/;
+export const pwRegex     = /^(?=.*[A-Za-z])(?=.*\d)[A-Za-z\d]{6,20}$/;
 export const nameRegex   = /^[가-힣a-zA-Z]{2,20}$/;
-export const emailRegex  = /^[A-Za-z0-9._%+-]+@[A-Za-z0-9-]+(?:\\.[A-Za-z0-9-]+)*$/;
-export const phoneRegex  = /^\\d{2,3}-\\d{3,4}-\\d{4}$/;     // ex: 010-1234-5678
-export const ssnRegex    = /^\\d{6}-\\d{7}$/;               // ex: 123456-1234567
+export const emailRegex  = /^[A-Za-z0-9._%+-]+@[A-Za-z0-9-]+(?:\.[A-Za-z0-9-]+)*$/;
+export const phoneRegex  = /^\d{2,3}-\d{3,4}-\d{4}$/;     // ex: 010-1234-5678
+export const ssnRegex    = /^\d{6}-\d{7}$/;               // ex: 123456-1234567

--- a/frontend/eco-insight/src/components/Auth/SignUp.jsx
+++ b/frontend/eco-insight/src/components/Auth/SignUp.jsx
@@ -1,13 +1,12 @@
 // src/components/Member/SignUp/SignUp.jsx
 import axios from "axios";
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import { useNavigate } from "react-router-dom";
 import {
   idRegex,
   pwRegex,
   nameRegex,
-  emailRegex,
-  // phoneRegex, ssnRegex no longer needed
+  emailRegex
 } from "./Regex";
 import logo from '../../assets/EcoInsigthLogo2.png';
 
@@ -22,38 +21,73 @@ const SignUp = () => {
     memberSsnFront: "",
     memberSsnBack: "",
   });
+  const [emailCode, setEmailCode] = useState("");
+  const [codeSent, setCodeSent] = useState(false);
+  const [codeVerified, setCodeVerified] = useState(false);
+  const [timer, setTimer] = useState(0);
   const [msg, setMsg] = useState("");
   const navigate = useNavigate();
+
+  // 인증번호 타이머
+  useEffect(() => {
+    let interval;
+    if (codeSent && timer > 0) {
+      interval = setInterval(() => setTimer(prev => prev - 1), 1000);
+    } else if (timer === 0) {
+      setCodeSent(false);
+    }
+    return () => clearInterval(interval);
+  }, [codeSent, timer]);
 
   const handleChange = (e) => {
     const { name, value } = e.target;
 
-    // 전화번호 자동 하이픈
     if (name === "memberPh") {
       const digits = value.replace(/\D/g, "");
       let formatted = digits;
       if (digits.length > 3 && digits.length <= 7) {
-        formatted = `${digits.slice(0, 3)}-${digits.slice(3)}`;
+        formatted = `${digits.slice(0,3)}-${digits.slice(3)}`;
       } else if (digits.length > 7) {
-        formatted = `${digits.slice(0, 3)}-${digits.slice(3, 7)}-${digits.slice(7, 11)}`;
+        formatted = `${digits.slice(0,3)}-${digits.slice(3,7)}-${digits.slice(7,11)}`;
       }
       setFormData(prev => ({ ...prev, memberPh: formatted }));
       return;
     }
-
-    // 주민등록번호 앞, 뒤 분리
     if (name === "memberSsnFront") {
-      const digits = value.replace(/\D/g, "").slice(0, 6);
-      setFormData(prev => ({ ...prev, memberSsnFront: digits }));
+      setFormData(prev => ({ ...prev, memberSsnFront: value.replace(/\D/g, "").slice(0,6) }));
       return;
     }
     if (name === "memberSsnBack") {
-      const digits = value.replace(/\D/g, "").slice(0, 7);
-      setFormData(prev => ({ ...prev, memberSsnBack: digits }));
+      setFormData(prev => ({ ...prev, memberSsnBack: value.replace(/\D/g, "").slice(0,7) }));
       return;
     }
-
     setFormData(prev => ({ ...prev, [name]: value }));
+  };
+
+  const sendCode = () => {
+    if (!emailRegex.test(formData.email)) {
+      setMsg("유효한 이메일을 입력해주세요.");
+      return;
+    }
+    axios.post("http://localhost/auth/send-code", { email: formData.email })
+      .then(() => {
+        setCodeSent(true);
+        setTimer(180); // 3분
+        setMsg("인증번호를 발송했습니다.");
+      })
+      .catch(error => setMsg(error.response?.data?.message || "인증번호 발송 실패"));
+  };
+
+  const verifyCode = () => {
+    axios.post("http://localhost/auth/verify-code", {
+      email: formData.email,
+      code: emailCode
+    })
+    .then(() => {
+      setCodeVerified(true);
+      setMsg("이메일 인증이 완료되었습니다!");
+    })
+    .catch(error => setMsg(error.response?.data?.message || "인증번호가 일치하지 않습니다."));
   };
 
   const handleSignUp = (e) => {
@@ -66,40 +100,24 @@ const SignUp = () => {
       email,
       memberPh,
       memberSsnFront,
-      memberSsnBack,
+      memberSsnBack
     } = formData;
 
-    if (!idRegex.test(memberId)) {
-      setMsg("아이디 형식이 올바르지 않습니다."); return;
-    }
-    if (!pwRegex.test(memberPw)) {
-      setMsg("비밀번호 형식이 올바르지 않습니다."); return;
-    }
-    if (memberPw !== memberPwConfirm) {
-      setMsg("비밀번호가 일치하지 않습니다."); return;
-    }
-    if (!nameRegex.test(memberName)) {
-      setMsg("이름은 2~20자, 한글/영문만 가능합니다."); return;
-    }
-    if (!emailRegex.test(email)) {
-      setMsg("올바른 이메일 형식을 입력해주세요."); return;
-    }
-    if (!/^\d{3}-\d{3,4}-\d{4}$/.test(memberPh)) {
-      setMsg("전화번호 형식이 올바르지 않습니다."); return;
-    }
-    if (memberSsnFront.length < 6 || memberSsnBack.length < 7) {
-      setMsg("주민등록번호를 정확히 입력해주세요."); return;
-    }
+    if (!idRegex.test(memberId)) { setMsg("아이디 형식이 올바르지 않습니다."); return; }
+    if (!pwRegex.test(memberPw)) { setMsg("비밀번호 형식이 올바르지 않습니다."); return; }
+    if (memberPw !== memberPwConfirm) { setMsg("비밀번호가 일치하지 않습니다."); return; }
+    if (!nameRegex.test(memberName)) { setMsg("이름은 2~20자, 한글/영문만 가능합니다."); return; }
+    if (!codeVerified) { setMsg("이메일 인증 후 회원가입 해주세요."); return; }
+    if (!/^\d{3}-\d{3,4}-\d{4}$/.test(memberPh)) { setMsg("전화번호 형식이 올바르지 않습니다."); return; }
+    if (memberSsnFront.length < 6 || memberSsnBack.length < 7) { setMsg("주민등록번호를 정확히 입력해주세요."); return; }
 
-    const memberSsn = `${memberSsnFront}-${memberSsnBack}`;
-
-    axios.post("http://localhost/auth/signup", {
+    axios.post("http://localhost/members", {
       memberId,
       memberPw,
       memberName,
       email,
       memberPh,
-      memberSsn,
+      memberSsn: `${memberSsnFront}-${memberSsnBack}`
     })
     .then(response => {
       if (response.status === 200 || response.status === 201) {
@@ -109,15 +127,11 @@ const SignUp = () => {
         setMsg("회원가입 중 오류가 발생했습니다.");
       }
     })
-    .catch(error => {
-      console.error(error);
-      setMsg(error.response?.data?.message || "회원가입에 실패했습니다.");
-    });
+    .catch(error => setMsg(error.response?.data?.message || "회원가입에 실패했습니다."));
   };
 
   return (
     <>
-      {/* 상단 로고 + 뒤로가기 */}
       <div className="flex items-center justify-between mb-4">
         <div className="logo-area flex items-center space-x-2">
           <img src={logo} alt="EcoInsightLogo" className="h-14 w-auto" />
@@ -125,37 +139,28 @@ const SignUp = () => {
         <button
           type="button"
           onClick={() => navigate(-1)}
-          className="inline-block bg-lime-400 transition px-4 py-1 rounded text-lg font-bold hover:bg-lime-500"
-        >
-          <span className="text-white">뒤로가기</span>
-        </button>
+          className="inline-block bg-lime-400 px-4 py-1 rounded text-lg font-bold hover:bg-lime-500"
+        >뒤로가기</button>
       </div>
-
-      {/* 회원가입 폼 */}
       <div className="flex items-center justify-center bg-gray-100 p-4 min-h-screen">
         <div className="bg-white w-full max-w-lg p-8 rounded-lg shadow">
           <h2 className="text-2xl font-bold mb-6 text-center">회원가입</h2>
           <form onSubmit={handleSignUp}>
             {/* 아이디 */}
             <div className="mb-4">
-              <label htmlFor="memberId" className="block mb-1 text-sm font-medium text-gray-700">
-                아이디
-              </label>
+              <label htmlFor="memberId" className="block mb-1 text-sm text-gray-700">아이디</label>
               <input
-                type="text"
                 id="memberId"
                 name="memberId"
                 value={formData.memberId}
                 onChange={handleChange}
                 placeholder="아이디를 입력하세요"
-                className="w-full px-4 py-2 border rounded focus:outline-none focus:ring-2 focus:ring-lime-400"
+                className="w-full px-4 py-2 border rounded focus:ring-2 focus:ring-lime-400"
               />
             </div>
             {/* 비밀번호 */}
             <div className="mb-4">
-              <label htmlFor="memberPw" className="block mb-1 text-sm font-medium text-gray-700">
-                비밀번호
-              </label>
+              <label htmlFor="memberPw" className="block mb-1 text-sm text-gray-700">비밀번호</label>
               <input
                 type="password"
                 id="memberPw"
@@ -163,14 +168,12 @@ const SignUp = () => {
                 value={formData.memberPw}
                 onChange={handleChange}
                 placeholder="비밀번호를 입력하세요"
-                className="w-full px-4 py-2 border rounded focus:outline-none focus:ring-2 focus:ring-lime-400"
+                className="w-full px-4 py-2 border rounded focus:ring-2 focus:ring-lime-400"
               />
             </div>
             {/* 비밀번호 확인 */}
             <div className="mb-4">
-              <label htmlFor="memberPwConfirm" className="block mb-1 text-sm font-medium text-gray-700">
-                비밀번호 확인
-              </label>
+              <label htmlFor="memberPwConfirm" className="block mb-1 text-sm text-gray-700">비밀번호 확인</label>
               <input
                 type="password"
                 id="memberPwConfirm"
@@ -178,75 +181,88 @@ const SignUp = () => {
                 value={formData.memberPwConfirm}
                 onChange={handleChange}
                 placeholder="비밀번호를 한 번 더 입력하세요"
-                className="w-full px-4 py-2 border rounded focus:outline-none focus:ring-2 focus:ring-lime-400"
+                className="w-full px-4 py-2 border rounded focus:ring-2 focus:ring-lime-400"
               />
             </div>
             {/* 이름 */}
             <div className="mb-4">
-              <label htmlFor="memberName" className="block mb-1 text-sm font-medium text-gray-700">
-                이름
-              </label>
+              <label htmlFor="memberName" className="block mb-1 text-sm text-gray-700">이름</label>
               <input
-                type="text"
                 id="memberName"
                 name="memberName"
                 value={formData.memberName}
                 onChange={handleChange}
                 placeholder="이름을 입력하세요"
-                className="w-full px-4 py-2 border rounded focus:outline-none focus:ring-2 focus:ring-lime-400"
+                className="w-full px-4 py-2 border rounded focus:ring-2 focus:ring-lime-400"
               />
             </div>
-            {/* 이메일 */}
+            {/* 이메일 & 인증 */}
             <div className="mb-4">
-              <label htmlFor="email" className="block mb-1 text-sm font-medium text-gray-700">
-                이메일
-              </label>
-              <input
-                type="text"
-                id="email"
-                name="email"
-                value={formData.email}
-                onChange={handleChange}
-                placeholder="example@domain.com"
-                className="w-full px-4 py-2 border rounded focus:outline-none focus:ring-2 focus:ring-lime-400"
-              />
+              <label htmlFor="email" className="block mb-1 text-sm text-gray-700">이메일</label>
+              <div className="flex space-x-2">
+                <input
+                  id="email"
+                  name="email"
+                  value={formData.email}
+                  onChange={handleChange}
+                  placeholder="example@domain.com"
+                  disabled={codeVerified}
+                  className="flex-grow px-4 py-2 border rounded focus:ring-2 focus:ring-lime-400"
+                />
+                <button
+                  type="button"
+                  onClick={sendCode}
+                  disabled={codeSent || codeVerified}
+                  className="px-4 py-2 bg-lime-400 text-white rounded hover:bg-lime-500"
+                >{codeVerified ? "인증완료" : "인증번호 발송"}</button>
+              </div>
             </div>
+            {codeSent && !codeVerified && (
+              <div className="mb-4 flex items-center space-x-2">
+                <input
+                  value={emailCode}
+                  onChange={e => setEmailCode(e.target.value)}
+                  placeholder="인증번호 입력"
+                  className="flex-grow px-4 py-2 border rounded focus:ring-2 focus:ring-lime-400"
+                />
+                <button
+                  type="button"
+                  onClick={verifyCode}
+                  className="px-4 py-2 bg-lime-400 text-white rounded hover:bg-lime-500"
+                >확인</button>
+                <span className="text-sm text-gray-600">
+                  {Math.floor(timer/60)}:{String(timer%60).padStart(2,'0')}
+                </span>
+              </div>
+            )}
             {/* 전화번호 */}
             <div className="mb-4">
-              <label htmlFor="memberPh" className="block mb-1 text-sm font-medium text-gray-700">
-                전화번호
-              </label>
+              <label htmlFor="memberPh" className="block mb-1 text-sm text-gray-700">전화번호</label>
               <input
-                type="text"
                 id="memberPh"
                 name="memberPh"
                 value={formData.memberPh}
                 onChange={handleChange}
                 placeholder="010-1234-5678"
-                className="w-full px-4 py-2 border rounded focus:outline-none focus:ring-2 focus:ring-lime-400"
+                className="w-full px-4 py-2 border rounded focus:ring-2 focus:ring-lime-400"
               />
             </div>
             {/* 주민등록번호 */}
             <div className="mb-4 flex space-x-2">
               <div className="w-2/5">
-                <label htmlFor="memberSsnFront" className="block mb-1 text-sm font-medium text-gray-700">
-                  주민등록번호 앞
-                </label>
+                <label htmlFor="memberSsnFront" className="block mb-1 text-sm text-gray-700">주민등록번호 앞</label>
                 <input
-                  type="text"
                   id="memberSsnFront"
                   name="memberSsnFront"
                   value={formData.memberSsnFront}
                   onChange={handleChange}
                   placeholder="123456"
                   maxLength={6}
-                  className="w-full px-4 py-2 border rounded focus:outline-none focus:ring-2 focus:ring-lime-400"
+                  className="w-full px-4 py-2 border rounded focus:ring-2 focus:ring-lime-400"
                 />
               </div>
               <div className="w-3/5">
-                <label htmlFor="memberSsnBack" className="block mb-1 text-sm font-medium text-gray-700">
-                  주민등록번호 뒤
-                </label>
+                <label htmlFor="memberSsnBack" className="block mb-1 text-sm text-gray-700">주민등록번호 뒤</label>
                 <input
                   type="password"
                   id="memberSsnBack"
@@ -255,22 +271,16 @@ const SignUp = () => {
                   onChange={handleChange}
                   placeholder="●●●●●●●"
                   maxLength={7}
-                  className="w-full px-4 py-2 border rounded focus:outline-none focus:ring-2 focus:ring-lime-400"
+                  className="w-full px-4 py-2 border rounded focus:ring-2 focus:ring-lime-400"
                 />
               </div>
             </div>
-
-            {/* 에러 메시지 */}
             {msg && <p className="text-red-500 text-sm mb-4">{msg}</p>}
-
-            {/* 제출 버튼 */}
             <div className="text-center">
               <button
                 type="submit"
-                className="bg-lime-400 text-white px-6 py-2 rounded hover:bg-lime-500 transition-colors font-semibold"
-              >
-                회원가입
-              </button>
+                className="bg-lime-400 text-white px-6 py-2 rounded hover:bg-lime-500 font-semibold"
+              >회원가입</button>
             </div>
           </form>
         </div>


### PR DESCRIPTION
[이메일 인증 앞단 생성 및 이메일 인증 코드 전송 기능 구현, 이메일 코드 인증 미구현]
2025/04/17 17:05 김대욱

AuthController.Java
PostMapping추가 ("/send-code", "/verify-code")
sendCodeEmail 메서드 추가
RequestBody로 email 전송 받아 authService에 sendCodeEmail메서드 호출
Map<String, String>으로 코드 번호 및 email 재전송

verifyCodeEmail 메서드 추가
authService에 verifyCodeEmail메서드 추가 기능 미구현

AuthService.Java, AuthServiceImpl.Java
Map<String, String>을 리턴하는 sendCodeEmail 메서드 추가
String email을 받아 verifyCodeCreate()메서드를 통해 랜덤 코드를 생성
JavaMailSender로 MimeMessage 객체 생성
MimeMessage객체를 통해 MimeMessageHelper객체 생성 (multipart 비활성화 encoding UTF-8)
입력받은 email을 전송하는 기능 구현
setTo(email)입력 받은 이메일로 전송
setSubject("") 전송할 이메일의 제목
setText("", ture) 전송할 이메일의 전송 내용
스트링 다음 true를 적어 html문법으로 보내겠다 명시

후에 HashMap에 담아 result 전송

현재 mapper의 메서드 호출 미구현
사유 : 데이터베이스 테이블 미구현

verifyCodeCreate() 메서드 생성
난수를 만들어 return

verifyCodeEmail() 메서드 생성
기능 미구현