### PR TITLE
관리자페이지 리펙토링

### DIFF
--- a/frontend/eco-insight/src/components/Board/AuthBoard/WriteAuthPage.jsx
+++ b/frontend/eco-insight/src/components/Board/AuthBoard/WriteAuthPage.jsx
@@ -1,93 +1,83 @@
+
 import React, { useRef, useState } from "react";
 import { useParams, useNavigate } from "react-router-dom";
 
 export default function WriteAuthPage() {
-    const { type } = useParams();
-    const navi = useNavigate();
-    const editorRef = useRef();
-    const [title, setTitle] = useState("");
-    const [previewImage, setPreviewImage] = useState(null); // 🖼️ 이미지 미리보기용 상태
-    const [option, setOption] = useState("");
+  const { type } = useParams();
+  const navi = useNavigate();
+  const editorRef = useRef();
+  const [title, setTitle] = useState("");
+  const [previewImage, setPreviewImage] = useState(null); // 🖼️ 이미지 미리보기용 상태
+  const [option, setOption] = useState("");
 
-    const handleOnChange = (e) => {
-        setOption(e.target.value);
-    };
+  const handleOnChange = (e) => {
+    setOption(e.target.value);
+  };
 
+  const handleUpload = () => {
+    try {
+      const content = editorRef.current.getInstance().getMarkdown();
 
-    const handleUpload = () => {
-        try {
-            const content = editorRef.current.getInstance().getMarkdown();
+      if (!title.trim() || !content.trim()) {
+        alert("제목과 내용을 모두 입력해주세요!");
+        return;
+      }
 
-            if (!title.trim() || !content.trim()) {
-                alert("제목과 내용을 모두 입력해주세요!");
-                return;
-            }
+      // TODO: 여기에 axios.post() 등 업로드 로직 작성
+      console.log("제목:", title);
+      console.log("내용:", content);
 
-        // TODO: 여기에 axios.post() 등 업로드 로직 작성
-            console.log("제목:", title);
-            console.log("내용:", content);
+      alert("게시물 업로드 완료!");
+      navi(`/board/cert`);
+    } catch (error) {
+      console.error("업로드 중 오류 발생:", error);
+      alert("업로드에 실패했습니다.");
+    }
+  };
 
-            alert("게시물 업로드 완료!");
-            navi(`/board/cert`);
-        } catch (error) {
-            console.error("업로드 중 오류 발생:", error);
-            alert("업로드에 실패했습니다.");
-        }
-    };
+  return (
+    <div className="max-w-3xl mx-auto mt-10 p-6 bg-white rounded-xl shadow-md">
+      <div className="mb-4 text-sm text-gray-500">인증게시판</div>
+      {/* 카테고리 */}
+      <div>
+        <select
+          value={option}
+          defaultValue="category"
+          onChange={handleOnChange}
+          className="mb-3 border px-11 py-2 rounded"
+        >
+          <option value="category">카테고리 선택</option>
+          <option value="item1">인증1</option>
+          <option value="item2">인증2</option>
+          <option value="item3">인증3</option>
+          <option value="item4">인증4</option>
+        </select>
+      </div>
 
-    return (
-        <div className="max-w-3xl mx-auto mt-10 p-6 bg-white rounded-xl shadow-md">
-        
-        <div className="mb-4 text-sm text-gray-500">인증게시판</div>
-        {/* 카테고리 */}
-        <div>
-            <select value={option} defaultValue="category" onChange={handleOnChange} className="mb-3 border px-11 py-2 rounded">
-                <option value="category">카테고리 선택</option>
-                <option value="item1">인증1</option>
-                <option value="item2">인증2</option>
-                <option value="item3">인증3</option>
-                <option value="item4">인증4</option>
-            </select>
-        </div>
+      {/* 제목 입력 */}
+      <input
+        type="text"
+        value={title}
+        onChange={(e) => setTitle(e.target.value)}
+        placeholder="제목을 입력하세요"
+        className="w-full p-4 text-xl font-semibold border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-green-300"
+      />
 
-        {/* 제목 입력 */}
-        <input
-            type="text"
-            value={title}
-            onChange={(e) => setTitle(e.target.value)}
-            placeholder="제목을 입력하세요"
-            className="w-full p-4 text-xl font-semibold border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-green-300"
-        />
+      {/* 텍스트 에디터 */}
+      <textarea
+        className="w-full h-60 p-4 border border-gray-300 rounded-md bg-gray-50 text-base focus:outline-none focus:ring-2 focus:ring-green-200"
+        placeholder="내용을 입력해주세요. 사진, 링크, 코드 등 자유롭게 작성할 수 있어요!"
+      />
 
-        {/* Toast UI 에디터 */}
-        <div className="mt-6">
-        <Editor
-            ref={editorRef}
-            height="400px"
-            initialEditType="wysiwyg"
-            previewStyle="vertical"
-            autofocus={true}
-            plugins={[colorSyntax]}
-            placeholder="내용을 입력해주세요. 마크다운을 자유롭게 활용할 수 있어요!"
-            hideModeSwitch={true}
-            toolbarItems={[
-                ["bold", "italic", "strike"],
-                ["hr", "quote"],
-                ["ul", "ol"],
-                ["image", "link"],
-                ["codeblock"],
-            ]}
-        />
-        </div>
-
-        {/* 업로드 버튼 */}
-        <div className="mt-4 flex justify-end">
-            <button
-                onClick={handleUpload}
-                className="bg-lime-400 hover:bg-green-600 text-white px-6 py-2 rounded-md font-bold transition">
-            업로드
-            </button>
-        </div>
+      {/* 업로드 버튼 */}
+      <div className="mt-4 flex justify-end">
+        <button
+          onClick={handleUpload}
+          className="bg-lime-400 hover:bg-green-600 text-white px-6 py-2 rounded-md font-bold transition"
+        >
+          업로드
+        </button>
+      </div>
     </div>
-    );
+  );
 }

--- a/frontend/eco-insight/src/components/Button/Button.jsx
+++ b/frontend/eco-insight/src/components/Button/Button.jsx
@@ -1,8 +1,19 @@
 
-const Button = () => {
+
+export const Button = () => {
   return (
     <></>
   );
 }
 
-export default Button;
+export const PageButton = ({children, onClick, className, key}) => {
+  return (
+    <button
+      key={key}
+      onClick={onClick}
+      className={`px-3 py-1 rounded bg-gray-200 hover:bg-lime-400 active:scale-105 ${className}`}
+    >
+      {children}
+    </button>
+  )
+}

--- a/frontend/eco-insight/src/components/Button/SelectOptions.jsx
+++ b/frontend/eco-insight/src/components/Button/SelectOptions.jsx
@@ -2,6 +2,8 @@
 const SelectOptions = () => {
   return (
     <>
+      <option value={1}>1</option>
+      <option value={5}>5</option>
       <option value={10}>10</option>
       <option value={15}>15</option>
       <option value={20}>20</option>

--- a/frontend/eco-insight/src/components/Input/SearchInput.jsx
+++ b/frontend/eco-insight/src/components/Input/SearchInput.jsx
@@ -1,0 +1,9 @@
+
+const SearchInput = () => {
+  return (
+
+    <></>
+  );
+}
+
+export default SearchInput;

--- a/frontend/eco-insight/src/components/Layout/AdminLayout.jsx
+++ b/frontend/eco-insight/src/components/Layout/AdminLayout.jsx
@@ -1,22 +1,15 @@
 import { Outlet, useNavigate, useLocation } from "react-router-dom";
 import logo from "../../assets/EcoInsigthLogo2.png";
 import MenuItem from "../Button/MenuItem";
-import { use, useState } from "react";
 
 
 const AdminLayout = () => {
   const navi = useNavigate();
   const location = useLocation();
-  const [isClicked, setIsClicked] = useState(false);
 
   const clickLogout = () => {
     localStorage.clear();
     navi("/");
-  }
-
-  const clickMenuItem = (link) => {
-    navi(link);
-
   }
 
   return (

--- a/frontend/eco-insight/src/components/Pagination/Pagination.jsx
+++ b/frontend/eco-insight/src/components/Pagination/Pagination.jsx
@@ -1,0 +1,57 @@
+import { PageButton } from "../Button/Button";
+
+const Pagination = ({ currentPage, totalPages, onPageChange }) => {
+  const pageLimit = 10;
+  const currentPageGroup = Math.floor(currentPage / pageLimit);
+  const startPage = currentPageGroup * pageLimit;
+  const endPage = Math.min(startPage + pageLimit, totalPages);
+
+  return (
+    <div className="flex items-center justify-center gap-2 mt-6">
+      {currentPageGroup > 0 && (
+        <PageButton
+          onClick={()=> onPageChange(startPage -1 )}
+        >
+          &hellip;
+        </PageButton>
+      )}
+
+      <PageButton
+        className={`${currentPage === 0 ? "hidden" : "block"}`}
+        onClick={() => onPageChange((p) => Math.max(p - 1, 0))}
+      >
+        이전
+      </PageButton>
+
+      {Array.from({ length: endPage-startPage }, (_, i) => startPage + i).map((n) => (
+        <PageButton
+          key={n}
+          onClick={() => onPageChange(n)}
+          className={`px-3 py-1 rounded ${
+            n === currentPage ? "bg-lime-400 text-white" : "bg-gray-200"
+          }`}
+        >
+          {n + 1}
+        </PageButton>
+      ))}
+      
+      <PageButton
+        className={`${currentPage === totalPages - 1 ? "hidden" : "block"}`}
+        onClick={() => onPageChange((p) => Math.min(p + 1, totalPages - 1))}
+      >
+        다음
+      </PageButton>
+
+      {endPage < totalPages && (
+        <PageButton
+          onClick={()=> onPageChange(endPage)}
+        >
+          &hellip;
+        </PageButton>
+      )}
+
+    </div>
+  );
+}
+
+export default Pagination;

--- a/frontend/eco-insight/src/pages/Admin/AccountManagementPage/AccountManagementPage.jsx
+++ b/frontend/eco-insight/src/pages/Admin/AccountManagementPage/AccountManagementPage.jsx
@@ -3,6 +3,7 @@ import SummaryCard from "../../../components/DashBoard/SummaryCard";
 import {memberList} from "../data";
 import dayjs from "dayjs";
 import SelectOptions from "../../../components/Button/SelectOptions";
+import Pagination from "../../../components/Pagination/Pagination";
 
 const AccountManagementPage = () => {
   const [members] = useState(memberList);
@@ -188,19 +189,11 @@ const AccountManagementPage = () => {
       </table>
 
       {/* 페이지네이션 */}
-      <div className="flex items-center justify-center gap-2 mt-6">
-        {Array.from({ length: totalPages }, (_, i) => i + 1).map((n) => (
-          <button
-            key={n}
-            onClick={() => setCurrentPage(n)}
-            className={`px-3 py-1 rounded ${
-              n === currentPage ? "bg-lime-400 text-white" : "bg-gray-200"
-            }`}
-          >
-            {n}
-          </button>
-        ))}
-      </div>
+      <Pagination
+        currentPage={currentPage}
+        totalPages={totalPages}
+        onPageChange={setCurrentPage}
+      />
     </div>
   );
 };

--- a/frontend/eco-insight/src/pages/Admin/AuthBoardManagementPage/AuthBoardManagementPage.jsx
+++ b/frontend/eco-insight/src/pages/Admin/AuthBoardManagementPage/AuthBoardManagementPage.jsx
@@ -1,6 +1,5 @@
 import { useContext, useState } from "react";
 import SummaryCard from "../../../components/DashBoard/SummaryCard";
-import dayjs from "dayjs";
 import SelectOptions from "../../../components/Button/SelectOptions";
 import { authBoardList } from "../data";
 import { AuthContext } from "../../../components/Context/AuthContext";
@@ -10,7 +9,6 @@ import Pagination from "../../../components/Pagination/Pagination";
 const AuthBoardManagementPage = () => {
   const { auth } = useContext(AuthContext);
   const [authBoards] = useState(authBoardList);
-  const [banPeriod, setBanPeriod] = useState();
   const [search, setSearch] = useState("");
   const [currentPage, setCurrentPage] = useState(1);
   const [rowsPerPage, setRowsPerPage] = useState(10);
@@ -39,7 +37,7 @@ const AuthBoardManagementPage = () => {
 
   const handleAuthBoard = (memberName) => {
     alert(`${memberName} 님의 게시글이 인증처리 되었습니다.`);
-    setBanPeriod(0);
+    
     setSelectedBoardNo(null);
   };
 
@@ -166,8 +164,8 @@ const AuthBoardManagementPage = () => {
                       {/* value = {auth.loginInfo.memberName} 으로 변경해야함 */}
                       <input
                         type="text"
+                        // value={auth.memberInfo.memberName}
                         value="관리자명"
-                        onChange={(e) => setBanPeriod(e.target.value)}
                         className="border px-3 py-2 w-32 rounded"
                       />
                       <button

--- a/frontend/eco-insight/src/pages/Admin/AuthBoardManagementPage/AuthBoardManagementPage.jsx
+++ b/frontend/eco-insight/src/pages/Admin/AuthBoardManagementPage/AuthBoardManagementPage.jsx
@@ -4,6 +4,7 @@ import dayjs from "dayjs";
 import SelectOptions from "../../../components/Button/SelectOptions";
 import { authBoardList } from "../data";
 import { AuthContext } from "../../../components/Context/AuthContext";
+import Pagination from "../../../components/Pagination/Pagination";
 
 
 const AuthBoardManagementPage = () => {
@@ -185,19 +186,11 @@ const AuthBoardManagementPage = () => {
       </table>
 
       {/* 페이지네이션 */}
-      <div className="flex items-center justify-center gap-2 mt-6">
-        {Array.from({ length: totalPages }, (_, i) => i + 1).map((n) => (
-          <button
-            key={n}
-            onClick={() => setCurrentPage(n)}
-            className={`px-3 py-1 rounded ${
-              n === currentPage ? "bg-lime-400 text-white" : "bg-gray-200"
-            }`}
-          >
-            {n}
-          </button>
-        ))}
-      </div>
+      <Pagination
+        currentPage={currentPage}
+        totalPages={totalPages}
+        onPageChange={setCurrentPage}
+      />
     </div>
   );
 };

--- a/frontend/eco-insight/src/pages/Admin/CommunityBoardManagementPage/CommunityBoardManagementPage.jsx
+++ b/frontend/eco-insight/src/pages/Admin/CommunityBoardManagementPage/CommunityBoardManagementPage.jsx
@@ -1,5 +1,7 @@
 import { useState } from "react";
 import SummaryCard from "../../../components/DashBoard/SummaryCard";
+import Pagination from "../../../components/Pagination/Pagination";
+import SelectOptions from "../../../components/Button/SelectOptions";
 
 // Mock 데이터
 const mockUsers = Array.from({ length: 20 }, (_, i) => ({
@@ -88,9 +90,7 @@ const CommunityBoardManagementPage = () => {
                 setCurrentPage(1);
               }}
             >
-              <option value={5}>5</option>
-              <option value={10}>10</option>
-              <option value={20}>20</option>
+              <SelectOptions />
             </select>
           </div>
           <div className="flex items-center gap-2">
@@ -164,19 +164,11 @@ const CommunityBoardManagementPage = () => {
       </div>
 
       {/* 페이지네이션 */}
-      <div className="flex items-center justify-center gap-2 mt-6">
-        {Array.from({ length: totalPages }, (_, i) => i + 1).map((n) => (
-          <button
-            key={n}
-            onClick={() => setCurrentPage(n)}
-            className={`px-3 py-1 rounded ${
-              n === currentPage ? "bg-purple-600 text-white" : "bg-gray-200"
-            }`}
-          >
-            {n}
-          </button>
-        ))}
-      </div>
+      <Pagination
+        currentPage={currentPage}
+        totalPages={totalPages}
+        onPageChange={setCurrentPage}
+      />
     </div>
   );
 };

--- a/frontend/eco-insight/src/pages/Admin/NoticeBoardManagementPage/NoticeBoardManagementPage.jsx
+++ b/frontend/eco-insight/src/pages/Admin/NoticeBoardManagementPage/NoticeBoardManagementPage.jsx
@@ -1,5 +1,7 @@
 import { useState } from "react";
 import SummaryCard from "../../../components/DashBoard/SummaryCard";
+import Pagination from "../../../components/Pagination/Pagination";
+import SelectOptions from "../../../components/Button/SelectOptions";
 
 // Mock 데이터
 const mockUsers = Array.from({ length: 20 }, (_, i) => ({
@@ -88,9 +90,7 @@ const NoticeBoardManagementPage = () => {
                 setCurrentPage(1);
               }}
             >
-              <option value={5}>5</option>
-              <option value={10}>10</option>
-              <option value={20}>20</option>
+              <SelectOptions />
             </select>
           </div>
           <div className="flex items-center gap-2">
@@ -164,19 +164,11 @@ const NoticeBoardManagementPage = () => {
       </div>
 
       {/* 페이지네이션 */}
-      <div className="flex items-center justify-center gap-2 mt-6">
-        {Array.from({ length: totalPages }, (_, i) => i + 1).map((n) => (
-          <button
-            key={n}
-            onClick={() => setCurrentPage(n)}
-            className={`px-3 py-1 rounded ${
-              n === currentPage ? "bg-purple-600 text-white" : "bg-gray-200"
-            }`}
-          >
-            {n}
-          </button>
-        ))}
-      </div>
+      <Pagination
+        currentPage={currentPage}
+        totalPages={totalPages}
+        onPageChange={setCurrentPage}
+      />
     </div>
   );
 };

--- a/frontend/eco-insight/src/pages/Admin/PointManagementPage/PointManagementPage.jsx
+++ b/frontend/eco-insight/src/pages/Admin/PointManagementPage/PointManagementPage.jsx
@@ -1,36 +1,39 @@
-import { useState } from "react";
+import { Fragment, useMemo, useState } from "react";
 import SummaryCard from "../../../components/DashBoard/SummaryCard";
 import {memberList} from "../data";
 import SelectOptions from "../../../components/Button/SelectOptions";
+import { PageButton } from "../../../components/Button/Button";
+import Pagination from "../../../components/Pagination/Pagination";
+
 
 
 const PointManagementPage = () => {
   const [members] = useState(memberList);
   const [pointValue, setPointValue] = useState(0);
   const [search, setSearch] = useState("");
-  const [currentPage, setCurrentPage] = useState(1);
+  const [currentPage, setCurrentPage] = useState(0);
   const [rowsPerPage, setRowsPerPage] = useState(10);
   const [sortOrder, setSortOrder] = useState("Newest");
   const [selectedUserId, setSelectedUserId] = useState(null);
 
-  const filteredMembers = members
-    .filter((u) =>
-      [u.memberName, u.memberId, u.memberPh].some((field) =>
-        field.toLowerCase().includes(search.toLowerCase())
+  const filteredMembers = useMemo(() => {
+    return members
+      .filter((u) =>
+        [u.memberName, u.memberId, u.memberPh].some((field) =>
+          field.toLowerCase().includes(search.toLowerCase())
+        )
       )
-    )
-    .sort((a, b) => {
-      if (sortOrder === "Newest") return b.id - a.id;
-      if (sortOrder === "Oldest") return a.id - b.id;
-      return 0;
-    });
+      .sort((a, b) => {
+        if (sortOrder === "Newest") return b.id - a.id;
+        if (sortOrder === "Oldest") return a.id - b.id;
+        return 0;
+      });
+  }, [members, search, sortOrder]);
 
-  const indexOfLastUser = currentPage * rowsPerPage;
-  const indexOfFirstUser = indexOfLastUser - rowsPerPage;
-  const currentMembers = filteredMembers.slice(
-    indexOfFirstUser,
-    indexOfLastUser
-  );
+  const currentMembers = useMemo(() => {
+    const startIndex = currentPage * rowsPerPage;
+    return filteredMembers.slice(startIndex, startIndex + rowsPerPage);
+  },[filteredMembers, currentPage, rowsPerPage]); 
   const totalPages = Math.ceil(filteredMembers.length / rowsPerPage);
 
   const handleApplyPoint = (memberName) => {
@@ -131,8 +134,8 @@ const PointManagementPage = () => {
         </thead>
         <tbody>
           {currentMembers.map((user) => (
-            <>
-              <tr key={user.memberNo} className="border-t hover:bg-gray-50">
+            <Fragment key={user.MemberNo}>
+              <tr className="border-t hover:bg-gray-50">
                 <td className="px-4 py-3">{user.memberName}</td>
                 <td>{user.memberId}</td>
                 <td>{user.memberPh}</td>
@@ -159,7 +162,7 @@ const PointManagementPage = () => {
                         {user.memberName} 님에게 포인트 지급:
                       </span>
                       <input
-                        type="number"
+                        type="text"
                         value={pointValue}
                         onChange={(e) => setPointValue(e.target.value)}
                         className="border px-3 py-2 w-32 rounded"
@@ -175,25 +178,18 @@ const PointManagementPage = () => {
                   </td>
                 </tr>
               )}
-            </>
+            </Fragment>
           ))}
         </tbody>
       </table>
 
       {/* 페이지네이션 */}
-      <div className="flex items-center justify-center gap-2 mt-6">
-        {Array.from({ length: totalPages }, (_, i) => i + 1).map((n) => (
-          <button
-            key={n}
-            onClick={() => setCurrentPage(n)}
-            className={`px-3 py-1 rounded ${
-              n === currentPage ? "bg-lime-400 text-white" : "bg-gray-200"
-            }`}
-          >
-            {n}
-          </button>
-        ))}
-      </div>
+      <Pagination
+        currentPage={currentPage}
+        totalPages={totalPages}
+        onPageChange={setCurrentPage}
+      />
+
     </div>
   );
 };

--- a/frontend/eco-insight/src/styles/Styles.js
+++ b/frontend/eco-insight/src/styles/Styles.js
@@ -6,3 +6,4 @@ export const Title = styled.div`
   background-color: #b9ff66;
   font-weight: bold;
 `;
+


### PR DESCRIPTION
[2025.04.20 01:47] 장준호

관리자 페이지 페이징 처리 리팩터링 및 기능 개선
- 사용하지 않는 변수 및 import 문 삭제
- 검색 기능 리팩터링을 위해 src/components/Input/SearchInput.jsx 추가
- 페이징 컴포넌트를 src/components/Pagination/Pagination.jsx로 분리
   - Props: currentPage, totalPages, onPageChange
   - 관리자 페이지에서는 currentPage, totalPages, setCurrentPage를 전달
- 페이지 번호 표시 개수를 최대 10개로 제한
- “다음” 버튼 및 다음 페이지 그룹 이동 버튼 추가
- 페이징 버튼 컴포넌트(PageButton)를 src/components/Button/Button.jsx에 생성
- Props: children, onClick, className, key
- 기본 스타일: px-3 py-1 rounded bg-gray-200 hover:bg-lime-400 active:scale-105

